### PR TITLE
Escape to math mode

### DIFF
--- a/piton.sty
+++ b/piton.sty
@@ -1019,7 +1019,9 @@ local function WithStyle(style,pattern)
 end
 local Escape =
   P(piton_begin_escape)
+  * Lc ("\\ensuremath{")
   * L ( ( 1 - P(piton_end_escape) ) ^ 1 )
+  * Lc ("}")
   * P(piton_end_escape)
 lpeg.locale(lpeg)
 local alpha, digit = lpeg.alpha, lpeg.digit


### PR DESCRIPTION
The escape-to-latex construct is in text mode. This modification lets escape to math mode. Maybe an option could be provided to choose in which mode to escape, or two escape characters (one for text mode, one for math mode) could be defined.